### PR TITLE
Solve issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # python-exchangeratesapi
-This is an unofficial wrapper for the awesome, free [ExchangeRatesAPI](https://exchangeratesapi.io/), which provides exchange rate lookups courtesy of the European Central Bank.
+This is an unofficial wrapper for the awesome, partly free [ExchangeRatesAPI](https://exchangeratesapi.io/), which provides exchange rate lookups courtesy of the European Central Bank.
 
 # Installation
 Either clone this repository into your project, or install with `pip`:
@@ -8,10 +8,11 @@ pip install python-exchangeratesapi
 ```
 
 # Usage
+First, you need to register at [ExchangeRatesAPI](https://exchangeratesapi.io/pricing/) for `ACCESS_KEY`.
 ```py
 from exchangeratesapi import Api
 
-api = Api()
+api = Api(ACCESS_KEY)
 
 # Get the latest foreign exchange rates:
 api.get_rates()
@@ -131,6 +132,6 @@ print(api.supported_currencies)
 # Supported currencies
 The list of currencies can be found at [European Central Bank's data set](https://www.ecb.europa.eu/stats/policy_and_exchange_rates/euro_reference_exchange_rates/html/index.en.html).
 
-If your currency is not in the list, then the library will be of not use to you. You may try [openexchangerates.org API](https://github.com/metglobal/openexchangerates) or some other service.
+If your currency is not in the list, then the library will be of no use to you. You may try [openexchangerates.org API](https://github.com/metglobal/openexchangerates) or some other service.
 # License
 MIT

--- a/exchangeratesapi/__init__.py
+++ b/exchangeratesapi/__init__.py
@@ -1,1 +1,1 @@
-from exchangeratesapi.api import Api
+from exchangeratesapi.api import Api, ExchangeRatesApiException

--- a/exchangeratesapi/api.py
+++ b/exchangeratesapi/api.py
@@ -1,4 +1,5 @@
 import requests
+import os
 from datetime import datetime
 
 
@@ -8,6 +9,7 @@ class ExchangeRatesApiException(Exception):
 
 
 class Api(object):
+    API_KEY = os.getenv('EXCHANGERATESAPI_KEY')
     API_URL = 'https://api.exchangeratesapi.io/v1/{endpoint}{params}'
     endpoints = {
         'latest': 'latest',
@@ -28,8 +30,12 @@ class Api(object):
     MIN_YEAR = 1999
     supported_currencies = None
 
-    def __init__(self, api_key):
+    def __init__(self, api_key=API_KEY):
         """Populate supported currencies list."""
+        if not api_key:
+            message = ('exchangeratesapi KEY is missing. '
+                       'Go to https://manage.exchangeratesapi.io/dashboard')
+            raise ExchangeRatesApiException(message)
         self.api_key = api_key
         self.supported_currencies = self._get_symbols()
 

--- a/exchangeratesapi/api.py
+++ b/exchangeratesapi/api.py
@@ -11,14 +11,19 @@ class Api(object):
     API_URL = 'https://api.exchangeratesapi.io/v1/{endpoint}{params}'
     endpoints = {
         'latest': 'latest',
-        'history': 'history',
+        #'history': 'history',
+        'timeseries': 'timeseries',
+        'symbols': 'symbols',
+        'convert': 'convert',
+        'fluctuation': 'fluctuation',
+        'historical': '{date}', #YYYY-MM-DD
     }
     params = {
         'key': 'access_key',
         'base': 'base',
         'symbols': 'symbols',
-        'start': 'start_at',
-        'end': 'end_at',
+        'start': 'start_date',
+        'end': 'end_date',
     }
     DATE_FORMAT = '%Y-%m-%d'
     MIN_YEAR = 1999
@@ -46,11 +51,11 @@ class Api(object):
         endpoint = ''
         params = '?{}={}'.format(self.params['key'], self.API_KEY)
         if start_date and end_date:
-            endpoint = self.endpoints['history']
+            endpoint = self.endpoints['timeseries']
             params += '&{}={}&{}={}'.format(self.params['start'], start_date,
                                            self.params['end'], end_date)
         elif start_date:
-            endpoint = start_date
+            endpoint = self.params['historical'].format(date=start_date)
         else:
             # latest
             endpoint = self.endpoints['latest']

--- a/exchangeratesapi/api.py
+++ b/exchangeratesapi/api.py
@@ -75,7 +75,8 @@ class Api(object):
         if date:
             return datetime.strptime(date, self.DATE_FORMAT)
 
-    def _get_error_message(self, error):
+    @staticmethod
+    def _get_error_message(error):
         """Method to get error message for raising Exception"""
         # Note: code and message are in root_url/v1
         # While code, type, and info are in root_url

--- a/exchangeratesapi/api.py
+++ b/exchangeratesapi/api.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 
 class Api(object):
-    API_URL = 'https://api.exchangeratesapi.io/{endpoint}{params}'
+    API_URL = 'https://api.exchangeratesapi.io/v1/{endpoint}{params}'
     endpoints = {
         'latest': 'latest',
         'history': 'history',

--- a/exchangeratesapi/api.py
+++ b/exchangeratesapi/api.py
@@ -9,6 +9,7 @@ class Api(object):
         'history': 'history',
     }
     params = {
+        'key': 'access_key',
         'base': 'base',
         'symbols': 'symbols',
         'start': 'start_at',
@@ -18,8 +19,9 @@ class Api(object):
     MIN_YEAR = 1999
     supported_currencies = None
 
-    def __init__(self):
+    def __init__(self, API_KEY):
         """Populate supported currencies list."""
+        self.API_KEY = API_KEY
         rates = self.get_rates()['rates']
         self.supported_currencies = [cur for cur in rates]
 
@@ -37,10 +39,10 @@ class Api(object):
             (str): exchangeratesapi.io url
         """
         endpoint = ''
-        params = ''
+        params = '?{}={}'.format(self.params['key'], self.API_KEY)
         if start_date and end_date:
             endpoint = self.endpoints['history']
-            params = '?{}={}&{}={}'.format(self.params['start'], start_date,
+            params += '&{}={}&{}={}'.format(self.params['start'], start_date,
                                            self.params['end'], end_date)
         elif start_date:
             endpoint = start_date
@@ -48,18 +50,11 @@ class Api(object):
             # latest
             endpoint = self.endpoints['latest']
         if base:
-            base_params = '{}={}'.format(self.params['base'], base)
-            if params != '':
-                params += '&'
-            else:
-                params = '?'
+            base_params = '&{}={}'.format(self.params['base'], base)
             params += base_params
         if target_list:
-            if params != '':
-                params += '&'
-            else:
-                params = '?'
-            params += "symbols={}".format(",".join(target_list))
+            params += "&{}={}".format(self.params['symbols'],
+                                      ",".join(target_list))
         return self.API_URL.format(endpoint=endpoint, params=params)
 
     def _check_date_format(self, date):

--- a/exchangeratesapi/api.py
+++ b/exchangeratesapi/api.py
@@ -11,7 +11,6 @@ class Api(object):
     API_URL = 'https://api.exchangeratesapi.io/v1/{endpoint}{params}'
     endpoints = {
         'latest': 'latest',
-        #'history': 'history',
         'timeseries': 'timeseries',
         'symbols': 'symbols',
         'convert': 'convert',
@@ -29,9 +28,9 @@ class Api(object):
     MIN_YEAR = 1999
     supported_currencies = None
 
-    def __init__(self, API_KEY):
+    def __init__(self, api_key):
         """Populate supported currencies list."""
-        self.API_KEY = API_KEY
+        self.api_key = api_key
         rates = self.get_rates()['rates']
         self.supported_currencies = [cur for cur in rates]
 
@@ -49,7 +48,7 @@ class Api(object):
             (str): exchangeratesapi.io url
         """
         endpoint = ''
-        params = '?{}={}'.format(self.params['key'], self.API_KEY)
+        params = '?{}={}'.format(self.params['key'], self.api_key)
         if start_date and end_date:
             endpoint = self.endpoints['timeseries']
             params += '&{}={}&{}={}'.format(self.params['start'], start_date,
@@ -77,7 +76,7 @@ class Api(object):
         if date:
             return datetime.strptime(date, self.DATE_FORMAT)
 
-    def _get_error_message(error):
+    def _get_error_message(self, error):
         """Method to get error message for raising Exception"""
         # Note: code and message are in root_url/v1
         # While code, type, and info are in root_url

--- a/exchangeratesapi/api.py
+++ b/exchangeratesapi/api.py
@@ -8,7 +8,7 @@ class ExchangeRatesApiException(Exception):
 
 
 class Api(object):
-    API_URL = 'https://api.exchangeratesapi.io/v1/{endpoint}{params}'
+    API_URL = 'http://api.exchangeratesapi.io/v1/{endpoint}{params}'
     endpoints = {
         'latest': 'latest',
         'timeseries': 'timeseries',
@@ -53,7 +53,7 @@ class Api(object):
             params += '&{}={}&{}={}'.format(self.params['start'], start_date,
                                            self.params['end'], end_date)
         elif start_date:
-            endpoint = self.params['historical'].format(date=start_date)
+            endpoint = self.endpoints['historical'].format(date=start_date)
         else:
             # latest
             endpoint = self.endpoints['latest']

--- a/exchangeratesapi/api.py
+++ b/exchangeratesapi/api.py
@@ -8,7 +8,7 @@ class ExchangeRatesApiException(Exception):
 
 
 class Api(object):
-    API_URL = 'http://api.exchangeratesapi.io/v1/{endpoint}{params}'
+    API_URL = 'https://api.exchangeratesapi.io/v1/{endpoint}{params}'
     endpoints = {
         'latest': 'latest',
         'timeseries': 'timeseries',

--- a/exchangeratesapi/api.py
+++ b/exchangeratesapi/api.py
@@ -110,10 +110,13 @@ class Api(object):
             (float): currency rate
 
         Examples:
-            >>> api.get_rate()
-            394.55
-            >>> api.get_rate('USD', 'EUR', date="2019-09-12")
-            0.897
+            ```
+            >>> api.get_rates()
+            ...
+            >>> api.get_rates('USD', ['EUR','CAD','GBP'],
+                              start_date="2019-09-12")
+            ...
+            ```
         """
         self._check_date_format(start_date)
         self._check_date_format(end_date)
@@ -141,10 +144,12 @@ class Api(object):
             (float): currency rate
 
         Examples:
+            ```
             >>> api.get_rate()
             394.55
-            >>> api.get_rate('USD', 'EUR', date="2019-09-12")
+            >>> api.get_rate('USD', 'EUR', start_date="2019-09-12")
             0.897
+            ```
         """
         res = self.get_rates(base=base, target_list=[target],
                              start_date=start_date, end_date=end_date)

--- a/exchangeratesapi/api.py
+++ b/exchangeratesapi/api.py
@@ -78,12 +78,6 @@ class Api(object):
     @staticmethod
     def _get_error_message(error):
         """Method to get error message for raising Exception"""
-        # Note: code and message are in root_url/v1
-        # While code, type, and info are in root_url
-        # But the docs has not been updated and it shows
-        # code and info in error
-        # The worse part is each key has a different meaning
-        # in different scenario.
         error_message = 'Web Message: {} - {}. '
         error_message += 'https://exchangeratesapi.io/documentation/#errors'
         code = error.get('code', None)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -75,18 +75,18 @@ def gbp():
 
 
 @pytest.fixture
-def usd_to_gbp_next_date():
-    # rate for USD and GBP on start_date + 1 day (27th)
-    return 0.604452179
+def usd_to_gbp_start_date():
+    # rate for USD and GBP on start_date (26th)
+    return 0.603114
 
 
 @pytest.fixture
 def usd_to_eur_next_date():
     # rate for EUR and USD on start_date + 1 day (27th)
-    return 0.7268498328
+    return 0.727658
 
 
 @pytest.fixture
 def eur_to_gbp_next_date():
     # rate for EUR and GBP on start_date + 1 day (27th)
-    return 0.8336
+    return 0.8275

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -27,15 +27,6 @@ def middle_date():
 
 
 @pytest.fixture
-def old_supported_currencies():
-    # for 02.04.2020
-    return ['CAD', 'HKD', 'ISK', 'PHP', 'DKK', 'HUF', 'CZK', 'AUD', 'RON',
-            'SEK', 'IDR', 'INR', 'BRL', 'RUB', 'HRK', 'JPY', 'THB', 'CHF',
-            'SGD', 'PLN', 'BGN', 'TRY', 'CNY', 'NOK', 'NZD', 'ZAR', 'USD',
-            'MXN', 'ILS', 'GBP', 'KRW', 'MYR']
-
-
-@pytest.fixture
 def supported_currencies():
     # for 2021-04-13
     return ('AED', 'AFN', 'ALL', 'AMD', 'ANG', 'AOA', 'ARS', 'AUD', 'AWG',
@@ -90,3 +81,13 @@ def usd_to_eur_next_date():
 def eur_to_gbp_next_date():
     # rate for EUR and GBP on start_date + 1 day (27th)
     return 0.8275
+
+
+@pytest.fixture
+def sample_error():
+    # Error when key is not provided
+    error = {
+                "code": "missing_access_key",
+                "message": "You have not supplied an API Access Key."
+            }
+    return error

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,7 +3,7 @@ import pytest
 
 @pytest.fixture
 def base_url():
-    return 'https://api.exchangeratesapi.io/v1/'
+    return 'http://api.exchangeratesapi.io/v1/'
 
 
 @pytest.fixture

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,7 +3,7 @@ import pytest
 
 @pytest.fixture
 def base_url():
-    return 'http://api.exchangeratesapi.io/v1/'
+    return 'https://api.exchangeratesapi.io/v1/'
 
 
 @pytest.fixture

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,6 +2,11 @@ import pytest
 
 
 @pytest.fixture
+def base_url():
+    return 'https://api.exchangeratesapi.io/v1/'
+
+
+@pytest.fixture
 def start_date():
     return '2014-03-26'
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -66,6 +66,11 @@ def gbp():
 
 
 @pytest.fixture
+def eur():
+    return 'EUR'
+
+
+@pytest.fixture
 def usd_to_gbp_start_date():
     # rate for USD and GBP on start_date (26th)
     return 0.603114

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -22,12 +22,36 @@ def middle_date():
 
 
 @pytest.fixture
-def supported_currencies():
+def old_supported_currencies():
     # for 02.04.2020
     return ['CAD', 'HKD', 'ISK', 'PHP', 'DKK', 'HUF', 'CZK', 'AUD', 'RON',
             'SEK', 'IDR', 'INR', 'BRL', 'RUB', 'HRK', 'JPY', 'THB', 'CHF',
             'SGD', 'PLN', 'BGN', 'TRY', 'CNY', 'NOK', 'NZD', 'ZAR', 'USD',
             'MXN', 'ILS', 'GBP', 'KRW', 'MYR']
+
+
+@pytest.fixture
+def supported_currencies():
+    # for 2021-04-13
+    return ('AED', 'AFN', 'ALL', 'AMD', 'ANG', 'AOA', 'ARS', 'AUD', 'AWG',
+            'AZN', 'BAM', 'BBD', 'BDT', 'BGN', 'BHD', 'BIF', 'BMD', 'BND',
+            'BOB', 'BRL', 'BSD', 'BTC', 'BTN', 'BWP', 'BYN', 'BYR', 'BZD',
+            'CAD', 'CDF', 'CHF', 'CLF', 'CLP', 'CNY', 'COP', 'CRC', 'CUC',
+            'CUP', 'CVE', 'CZK', 'DJF', 'DKK', 'DOP', 'DZD', 'EGP', 'ERN',
+            'ETB', 'EUR', 'FJD', 'FKP', 'GBP', 'GEL', 'GGP', 'GHS', 'GIP',
+            'GMD', 'GNF', 'GTQ', 'GYD', 'HKD', 'HNL', 'HRK', 'HTG', 'HUF',
+            'IDR', 'ILS', 'IMP', 'INR', 'IQD', 'IRR', 'ISK', 'JEP', 'JMD',
+            'JOD', 'JPY', 'KES', 'KGS', 'KHR', 'KMF', 'KPW', 'KRW', 'KWD',
+            'KYD', 'KZT', 'LAK', 'LBP', 'LKR', 'LRD', 'LSL', 'LTL', 'LVL',
+            'LYD', 'MAD', 'MDL', 'MGA', 'MKD', 'MMK', 'MNT', 'MOP', 'MRO',
+            'MUR', 'MVR', 'MWK', 'MXN', 'MYR', 'MZN', 'NAD', 'NGN', 'NIO',
+            'NOK', 'NPR', 'NZD', 'OMR', 'PAB', 'PEN', 'PGK', 'PHP', 'PKR',
+            'PLN', 'PYG', 'QAR', 'RON', 'RSD', 'RUB', 'RWF', 'SAR', 'SBD',
+            'SCR', 'SDG', 'SEK', 'SGD', 'SHP', 'SLL', 'SOS', 'SRD', 'STD',
+            'SVC', 'SYP', 'SZL', 'THB', 'TJS', 'TMT', 'TND', 'TOP', 'TRY',
+            'TTD', 'TWD', 'TZS', 'UAH', 'UGX', 'USD', 'UYU', 'UZS', 'VEF',
+            'VND', 'VUV', 'WST', 'XAF', 'XAG', 'XAU', 'XCD', 'XDR', 'XOF',
+            'XPF', 'YER', 'ZAR', 'ZMK', 'ZMW', 'ZWL')
 
 
 @pytest.fixture

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -6,60 +6,58 @@ from exchangeratesapi import Api
 api = Api()
 
 
-def test_get_api_url_latest():
+def test_get_api_url_latest(base_url):
     url = api._get_api_url(None, None, None, None)
-    assert url == 'https://api.exchangeratesapi.io/latest'
+    assert url == '{}latest'.format(base_url)
 
 
-def test_get_api_url_one_latest_targ(targets):
+def test_get_api_url_one_latest_targ(base_url, targets):
     url = api._get_api_url(None, targets, None, None)
-    assert url == 'https://api.exchangeratesapi.io/latest?symbols={}'.format(
+    assert url == '{}latest?symbols={}'.format(base_url,
                     ",".join(targets))
 
 
-def test_get_api_url_one_date(start_date):
+def test_get_api_url_one_date(base_url, start_date):
     url = api._get_api_url(None, None, start_date, None)
-    assert url == 'https://api.exchangeratesapi.io/{}'.format(start_date)
+    assert url == '{}{}'.format(base_url, start_date)
 
 
-def test_get_api_url_one_date_targ(start_date, targets):
+def test_get_api_url_one_date_targ(base_url, start_date, targets):
     url = api._get_api_url(None, targets, start_date, None)
-    assert url == 'https://api.exchangeratesapi.io/{}?symbols={}'.format(
-                    start_date, ",".join(targets))
+    assert url == '{}{}?symbols={}'.format(
+                    base_url, start_date, ",".join(targets))
 
 
-def test_get_api_url_two_dates(start_date, end_date):
+def test_get_api_url_two_dates(base_url, start_date, end_date):
     url = api._get_api_url(None, None, start_date=start_date,
                            end_date=end_date)
-    assert url == ('https://api.exchangeratesapi.io/history'
-                   '?start_at={}&end_at={}'.format(start_date, end_date))
+    assert url == ('{}history?start_at={}&end_at={}'.format(
+                    base_url, start_date, end_date))
 
 
-def test_get_api_url_two_dates_targ(start_date, end_date, targets):
+def test_get_api_url_two_dates_targ(base_url, start_date, end_date, targets):
     url = api._get_api_url(None, targets, start_date=start_date,
                            end_date=end_date)
-    assert url == ('https://api.exchangeratesapi.io/history'
-                   '?start_at={}&end_at={}&symbols={}'.format(
-                    start_date, end_date, ",".join(targets)))
+    assert url == ('{}history?start_at={}&end_at={}&symbols={}'.format(
+                    base_url, start_date, end_date, ",".join(targets)))
 
 
-def test_get_api_url_latest_curr(usd):
+def test_get_api_url_latest_curr(base_url, usd):
     url = api._get_api_url(usd, None, None, None)
-    assert url == 'https://api.exchangeratesapi.io/latest?base={}'.format(usd)
+    assert url == '{}latest?base={}'.format(base_url, usd)
 
 
-def test_get_api_url_one_date_curr(usd, start_date):
+def test_get_api_url_one_date_curr(base_url, usd, start_date):
     url = api._get_api_url(usd, None, start_date, None)
-    assert url == 'https://api.exchangeratesapi.io/{}?base={}'.format(
-                    start_date, usd)
+    assert url == '{}{}?base={}'.format(base_url, start_date, usd)
 
 
-def test_get_api_url_two_dates_curr_targ(usd, start_date, end_date, targets):
+def test_get_api_url_two_dates_curr_targ(base_url, usd, start_date,
+                                         end_date, targets):
     url = api._get_api_url(usd, targets, start_date=start_date,
                            end_date=end_date)
-    assert url == ('https://api.exchangeratesapi.io/history'
-                   '?start_at={}&end_at={}&base={}&symbols={}'.format(
-                    start_date, end_date, usd, ",".join(targets)))
+    assert url == ('{}history?start_at={}&end_at={}&base={}&symbols={}'.format(
+                    base_url, start_date, end_date, usd, ",".join(targets)))
 
 
 def test_check_date_format(start_date):

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -99,8 +99,8 @@ def test_get_rates_two_date(start_date, end_date, middle_date):
     assert type(res) == dict
     assert 'rates' in res
     assert 'base' in res
-    assert 'start_at' in res
-    assert 'end_at' in res
+    assert 'start_date' in res
+    assert 'end_date' in res
     assert type(res['rates']) == dict
     assert start_date in res['rates']
     assert end_date in res['rates']
@@ -144,21 +144,21 @@ def test_get_rate_targ(gbp):
     assert type(res) == float
 
 
-def test_get_rate_targ_one_date(gbp, start_date, eur_to_gbp_next_date):
-    res = api.get_rate(target=gbp, start_date=start_date)
+def test_get_rate_targ_one_date(gbp, next_date, eur_to_gbp_next_date):
+    res = api.get_rate(target=gbp, start_date=next_date)
     assert res == eur_to_gbp_next_date  # rate for that date
 
 
 def test_get_rate_curr_targ_one_date(usd, gbp, start_date,
-                                     usd_to_gbp_next_date):
+                                     usd_to_gbp_start_date):
     res = api.get_rate(usd, gbp, start_date)
-    assert res == usd_to_gbp_next_date  # rate for that date
+    assert res == usd_to_gbp_start_date  # rate for that date
 
 
 def test_get_rate_curr_targ_two_dates(usd, gbp, start_date, end_date,
-                                      usd_to_gbp_next_date):
+                                      usd_to_gbp_start_date):
     res = api.get_rate(usd, gbp, start_date, end_date)
-    assert res[start_date][gbp] == usd_to_gbp_next_date
+    assert res[start_date][gbp] == usd_to_gbp_start_date
 
 
 def test_supported_currencies(supported_currencies):

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -10,56 +10,61 @@ api = Api(access_key)
 
 def test_get_api_url_latest(base_url):
     url = api._get_api_url(None, None, None, None)
-    assert url == '{}latest'.format(base_url)
+    assert url == '{}latest?access_key={}'.format(
+                    base_url, access_key)
 
 
 def test_get_api_url_one_latest_targ(base_url, targets):
     url = api._get_api_url(None, targets, None, None)
-    assert url == '{}latest?symbols={}'.format(base_url,
-                    ",".join(targets))
+    assert url == '{}latest?access_key={}&symbols={}'.format(
+                    base_url, access_key, ",".join(targets))
 
 
 def test_get_api_url_one_date(base_url, start_date):
     url = api._get_api_url(None, None, start_date, None)
-    assert url == '{}{}'.format(base_url, start_date)
+    assert url == '{}{}?access_key={}'.format(base_url, start_date, access_key)
 
 
 def test_get_api_url_one_date_targ(base_url, start_date, targets):
     url = api._get_api_url(None, targets, start_date, None)
-    assert url == '{}{}?symbols={}'.format(
-                    base_url, start_date, ",".join(targets))
+    assert url == '{}{}?access_key={}&symbols={}'.format(
+                    base_url, start_date, access_key, ",".join(targets))
 
 
 def test_get_api_url_two_dates(base_url, start_date, end_date):
     url = api._get_api_url(None, None, start_date=start_date,
                            end_date=end_date)
-    assert url == ('{}history?start_at={}&end_at={}'.format(
-                    base_url, start_date, end_date))
+    assert url == ('{}history?access_key={}&start_date={}&end_date={}'
+                    .format(base_url, access_key, start_date, end_date))
 
 
 def test_get_api_url_two_dates_targ(base_url, start_date, end_date, targets):
     url = api._get_api_url(None, targets, start_date=start_date,
                            end_date=end_date)
-    assert url == ('{}history?start_at={}&end_at={}&symbols={}'.format(
-                    base_url, start_date, end_date, ",".join(targets)))
+    assert url == ('{}history?access_key={}&start_date={}&end_date={}'
+                    '&symbols={}'.format(base_url, access_key, start_date,
+                    end_date, ",".join(targets)))
 
 
 def test_get_api_url_latest_curr(base_url, usd):
     url = api._get_api_url(usd, None, None, None)
-    assert url == '{}latest?base={}'.format(base_url, usd)
+    assert url == '{}latest?access_key={}&base={}'.format(
+                    base_url, access_key, usd)
 
 
 def test_get_api_url_one_date_curr(base_url, usd, start_date):
     url = api._get_api_url(usd, None, start_date, None)
-    assert url == '{}{}?base={}'.format(base_url, start_date, usd)
+    assert url == '{}{}?access_key={}base={}'.format(
+                    base_url, start_date, access_key, usd)
 
 
 def test_get_api_url_two_dates_curr_targ(base_url, usd, start_date,
                                          end_date, targets):
     url = api._get_api_url(usd, targets, start_date=start_date,
                            end_date=end_date)
-    assert url == ('{}history?start_at={}&end_at={}&base={}&symbols={}'.format(
-                    base_url, start_date, end_date, usd, ",".join(targets)))
+    assert url == ('{}history?access_key={}&start_date={}&end_date={}'
+                    '&base={}&symbols={}'.format(base_url, access_key,
+                    start_date, end_date, usd, ",".join(targets)))
 
 
 def test_check_date_format(start_date):

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -183,8 +183,12 @@ def test_supported_currencies(supported_currencies):
     assert api.supported_currencies == supported_currencies
 
 
-def test_is_currency_supported(usd):
+def test_is_currency_supported_eur(usd):
     assert api.is_currency_supported(usd)
+
+
+def test_is_currency_supported_eur(eur):
+    assert api.is_currency_supported(eur)
 
 
 def test_is_currency_supported_fail(usd):

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -1,7 +1,7 @@
 import datetime
 import os
 import pytest
-from exchangeratesapi import Api
+from exchangeratesapi import Api, ExchangeRatesApiException
 
 
 access_key = os.environ['EXCHANGERATESAPI_FREE_KEY']
@@ -74,6 +74,24 @@ def test_check_date_format(start_date):
 def test_check_date_format_fail():
     with pytest.raises(ValueError):
         api._check_date_format("22.02.2012")
+
+
+def test_get_url(base_url):
+    url = api._get_api_url(None, None, None, None)
+    res = api._get_url(url)
+    assert type(res)==dict
+
+
+def test_get_url_fail(base_url):
+    with pytest.raises(ExchangeRatesApiException):
+        api._get_url(base_url)
+
+
+def test_get_error_message(sample_error):
+    error_message = api._get_error_message(sample_error)
+    assert sample_error['code'] in error_message
+    assert sample_error['message'] in error_message
+    assert 'https://exchangeratesapi.io/documentation/#errors' in error_message
 
 
 def test_get_rates():

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -34,14 +34,14 @@ def test_get_api_url_one_date_targ(base_url, start_date, targets):
 def test_get_api_url_two_dates(base_url, start_date, end_date):
     url = api._get_api_url(None, None, start_date=start_date,
                            end_date=end_date)
-    assert url == ('{}history?access_key={}&start_date={}&end_date={}'
+    assert url == ('{}timeseries?access_key={}&start_date={}&end_date={}'
                     .format(base_url, access_key, start_date, end_date))
 
 
 def test_get_api_url_two_dates_targ(base_url, start_date, end_date, targets):
     url = api._get_api_url(None, targets, start_date=start_date,
                            end_date=end_date)
-    assert url == ('{}history?access_key={}&start_date={}&end_date={}'
+    assert url == ('{}timeseries?access_key={}&start_date={}&end_date={}'
                     '&symbols={}'.format(base_url, access_key, start_date,
                     end_date, ",".join(targets)))
 
@@ -54,7 +54,7 @@ def test_get_api_url_latest_curr(base_url, usd):
 
 def test_get_api_url_one_date_curr(base_url, usd, start_date):
     url = api._get_api_url(usd, None, start_date, None)
-    assert url == '{}{}?access_key={}base={}'.format(
+    assert url == '{}{}?access_key={}&base={}'.format(
                     base_url, start_date, access_key, usd)
 
 
@@ -62,7 +62,7 @@ def test_get_api_url_two_dates_curr_targ(base_url, usd, start_date,
                                          end_date, targets):
     url = api._get_api_url(usd, targets, start_date=start_date,
                            end_date=end_date)
-    assert url == ('{}history?access_key={}&start_date={}&end_date={}'
+    assert url == ('{}timeseries?access_key={}&start_date={}&end_date={}'
                     '&base={}&symbols={}'.format(base_url, access_key,
                     start_date, end_date, usd, ",".join(targets)))
 

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -1,9 +1,11 @@
 import datetime
+import os
 import pytest
 from exchangeratesapi import Api
 
 
-api = Api()
+access_key = os.environ['EXCHANGERATESAPI_FREE_KEY']
+api = Api(access_key)
 
 
 def test_get_api_url_latest(base_url):

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -4,7 +4,7 @@ import pytest
 from exchangeratesapi import Api, ExchangeRatesApiException
 
 
-access_key = os.environ['EXCHANGERATESAPI_FREE_KEY']
+access_key = os.environ['EXCHANGERATESAPI_KEY']
 api = Api(access_key)
 
 


### PR DESCRIPTION
As mentioned in issue #5, API_KEY is now required by [exchangeratesapi](https://exchangeratesapi.io/). It's quite surprising cause I used the API a few weeks. But by reading the [documentation](https://exchangeratesapi.io/documentation), I discovered there's more to it including changes to endpoints and params. The old documentation for comparison is [this](https://web.archive.org/web/20210328014153/http://exchangeratesapi.io/).

Done:
- [x] issue #5 in the first commit
- [x] Change base url from https://api.exchangeratesapi.io to https://api.exchangeratesapi.io/v1
- [x] issue #4 by creating a class ExchangeRatesApiException and _get_error_message method
- [x] update endpoints and params
- [x] resolve issue #2 and correct examples.
- [x] Resolve issue #3 by using symbols endpoint
- [x] Update tests

To Do:
- [ ] Work on other endpoints (done in #7)